### PR TITLE
Remove unnecessary fields from the descriptor typedef

### DIFF
--- a/polymer.externs.js
+++ b/polymer.externs.js
@@ -13,11 +13,7 @@
  */
 
 /**
- * @param {!{
- *   is: string,
- *   observers: (!Object<string, string>|undefined),
- *   mixins: (!Array<!Object>|undefined)
- * }} descriptor The Polymer descriptor of the element.
+ * @param {!{is: string}} descriptor The Polymer descriptor of the element.
  * @see https://github.com/Polymer/polymer/blob/0.8-preview/PRIMER.md#custom-element-registration
  */
 var Polymer = function(descriptor) {};


### PR DESCRIPTION
We don't need the other things because only explicitly required fields should be in a typedef like this. Extra fields are fine.
