### PR TITLE
listen/unlisten can be used on window as well

### DIFF
--- a/polymer.externs.js
+++ b/polymer.externs.js
@@ -290,7 +290,7 @@ PolymerElement.prototype.attributeFollows = function(name, newNode, oldNode) {};
 /**
  * Convenience method to add an event listener on a given element, late bound to
  * a named method on this element.
- * @param {!Element} node Element to add event listener to.
+ * @param {!EventTarget} node Element to add event listener to.
  * @param {string} eventName Name of event to listen for.
  * @param {string} methodName Name of handler method on this to call.
  */
@@ -298,7 +298,7 @@ PolymerElement.prototype.listen = function(node, eventName, methodName) {};
 
 /**
  * Convenience method to remove an event listener from a given element.
- * @param {!Element} node Element to remove event listener from.
+ * @param {!EventTarget} node Element to remove event listener from.
  * @param {string} eventName Name of event to stop listening for.
  * @param {string} methodName Name of handler method on this to remove.
  */


### PR DESCRIPTION
EventTarget is the interface implemented by both window and regular dom nodes that lets us add event listeners and dispatch events.
