### PR TITLE
Add extern methods to PolymerDomApi prototype

### DIFF
--- a/polymer.externs.js
+++ b/polymer.externs.js
@@ -596,12 +596,12 @@ PolymerDomApi.prototype.setAttribute = function(attribute, value) {};
 PolymerDomApi.prototype.removeAttribute = function(attribute) {};
 
 /**
- * @param {Function} callback
- * @return {Object}
+ * @param {!Function} callback
+ * @return {!{fn: !Function=, _nodes: !Array<!Node>}}
  */
 PolymerDomApi.prototype.observeNodes = function(callback) {};
 
-/** @param {Object} handle */
+/** @param {!{fn: !Function=, _nodes: !Array<!Node>}} handle */
 PolymerDomApi.prototype.unobserveNodes = function(handle) {};
 
 /** @type {?DOMTokenList} */

--- a/polymer.externs.js
+++ b/polymer.externs.js
@@ -595,6 +595,15 @@ PolymerDomApi.prototype.setAttribute = function(attribute, value) {};
 /** @param {string} attribute */
 PolymerDomApi.prototype.removeAttribute = function(attribute) {};
 
+/**
+ * @param {Function} callback
+ * @return {Object}
+ */
+PolymerDomApi.prototype.observeNodes = function(callback) {};
+
+/** @param {Object} handle */
+PolymerDomApi.prototype.unobserveNodes = function(handle) {};
+
 /** @type {?DOMTokenList} */
 PolymerDomApi.prototype.classList;
 


### PR DESCRIPTION
Adds extern declarations for PolymerDomApi.prototype.observeNodes and PolymerDomApi.prototype.unobserveNodes. These are used in the MD Settings implementation within Chromium.
