### PR TITLE
Adding .dragging DOM api prototype

### DIFF
--- a/polymer.externs.js
+++ b/polymer.externs.js
@@ -3,7 +3,7 @@
  *
  * @externs
  * @license
- * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * Copyright 2015 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt. The complete set of authors may be
  * found at http://polymer.github.io/AUTHORS.txt. The complete set of
@@ -597,6 +597,9 @@ PolymerDomApi.prototype.removeAttribute = function(attribute) {};
 
 /** @type {?DOMTokenList} */
 PolymerDomApi.prototype.classList;
+
+/** @type {?DOMTokenList} */
+PolymerDomApi.prototype.dragging;
 
 /**
  * @param {string} selector


### PR DESCRIPTION
In Polymer, .dragging is an option akin to .classList.
This CL fixes a Closure Compiler warning about accessing
.dragging.
