### PR TITLE
add PolymerDomApi#deepContains

### DIFF
--- a/polymer.externs.js
+++ b/polymer.externs.js
@@ -538,6 +538,12 @@ PolymerElement.prototype._logf = function(var_args) {};
  */
 var PolymerDomApi = function() {};
 
+/**
+ * @param {Node} node
+ * @return {boolean}
+ */
+PolymerDomApi.prototype.deepContains = function(node) {};
+
 /** @param {!Node} node */
 PolymerDomApi.prototype.appendChild = function(node) {};
 

--- a/polymer.externs.js
+++ b/polymer.externs.js
@@ -539,7 +539,7 @@ PolymerElement.prototype._logf = function(var_args) {};
 var PolymerDomApi = function() {};
 
 /**
- * @param {Node} node
+ * @param {?Node} node
  * @return {boolean}
  */
 PolymerDomApi.prototype.deepContains = function(node) {};


### PR DESCRIPTION
/cc @jklein24 @rictic 

why are we duplicating this API in an externs when it's actually provided in a script, again?  should we just be depending on the implementation instead?
