### PR TITLE
loosen isLightDescendant's @param type to Node

### DIFF
--- a/polymer.externs.js
+++ b/polymer.externs.js
@@ -455,7 +455,7 @@ PolymerElement.prototype.importHref = function(href, onload, onerror) {};
 
 /**
  * Checks whether an element is in this element's light DOM tree.
- * @param {HTMLElement=} node The element to be checked.
+ * @param {Node} node The element to be checked.
  * @return {boolean} true if node is in this element's light DOM tree.
  */
 PolymerElement.prototype.isLightDescendant = function(node) {};

--- a/polymer.externs.js
+++ b/polymer.externs.js
@@ -455,7 +455,7 @@ PolymerElement.prototype.importHref = function(href, onload, onerror) {};
 
 /**
  * Checks whether an element is in this element's light DOM tree.
- * @param {Node} node The element to be checked.
+ * @param {?Node} node The element to be checked.
  * @return {boolean} true if node is in this element's light DOM tree.
  */
 PolymerElement.prototype.isLightDescendant = function(node) {};


### PR DESCRIPTION
should I update all the occurrences of "element" in the doc?  it'd be nice if we didn't duplicate this in externs, IMO (there's already a definition [here](https://github.com/Polymer/polymer/blob/cb68ce54ebdcfb2d6f7342e801574881fb158076/src/standard/utils.html#L408)).

/cc @jklein24 @rictic 

this depends on: https://github.com/Polymer/polymer/pull/3079
