### PR TITLE
listen and unlisten can accept null nodes

### DIFF
--- a/polymer.externs.js
+++ b/polymer.externs.js
@@ -354,7 +354,7 @@ PolymerElement.prototype.listen = function(node, eventName, methodName) {};
 
 /**
  * Convenience method to remove an event listener from a given element.
- * @param {!EventTarget} node Element to remove event listener from.
+ * @param {?EventTarget} node Element to remove event listener from.
  * @param {string} eventName Name of event to stop listening for.
  * @param {string} methodName Name of handler method on this to remove.
  */


### PR DESCRIPTION
They're implemented defensively: 
  https://github.com/Polymer/polymer/blob/cb68ce54ebdcfb2d6f7342e801574881fb158076/src/standard/events.html#L88
  https://github.com/Polymer/polymer/blob/cb68ce54ebdcfb2d6f7342e801574881fb158076/src/standard/events.html#L158
