### PR TITLE
moved queryEffectiveChildren to PolymerElement

### DIFF
--- a/polymer.externs.js
+++ b/polymer.externs.js
@@ -302,6 +302,12 @@ PolymerElement.prototype.getEffectiveChildren = function() {};
 PolymerElement.prototype.getEffectiveTextContent = function() {};
 
 /**
+ * @param {string} selector
+ * @return {?HTMLElement}
+ */
+PolymerElement.prototype.queryEffectiveChildren = function(selector) {};
+
+/**
  * Fire an event.
  *
  * @param {string} type An event name.
@@ -743,12 +749,6 @@ PolymerDomApi.prototype.classList;
  * @return {!Array<!HTMLElement>}
  */
 PolymerDomApi.prototype.queryDistributedElements = function(selector) {};
-
-/**
- * @param {string} selector
- * @return {!Array<!HTMLElement>}
- */
-PolymerDomApi.prototype.queryEffectiveChildren = function(selector) {};
 
 /**
  * A Polymer Event API.


### PR DESCRIPTION
I had it off a bit. It is in Polymer.Base not Polymer.dom. See [here](https://github.com/Polymer/polymer/blob/edb59eb6283074ce54f374b30b884c9f9fcf9f5f/src/standard/utils.html#L155). Also changed the return type to the correct type.
